### PR TITLE
fix: 유저 리스트 페이지네이션 인덱스 수정

### DIFF
--- a/src/components/users/user-list.tsx
+++ b/src/components/users/user-list.tsx
@@ -11,8 +11,8 @@ const PAGE_SIZE = 10;
 export default function UserList() {
   const searchParams = useSearchParams();
 
-  const page = parseInt(searchParams.get("page") || "0");
-  const params = { page, size: PAGE_SIZE };
+  const page = parseInt(searchParams.get("page") || "1");
+  const params = { page: page - 1, size: PAGE_SIZE };
 
   const { data, isLoading, error } = useUsers(params);
 


### PR DESCRIPTION
## 📌 작업 내용 및 특이 사항

- 유저 리스트 조회 시 페이지네이션 디폴트 값이 0이 아닌 1로 적용되는 현상 수정