### PR TITLE
feat: 제보 아이템에 spotName 추가

### DIFF
--- a/src/components/suggestions/trash-can-list-item.tsx
+++ b/src/components/suggestions/trash-can-list-item.tsx
@@ -46,6 +46,9 @@ export default function TrashCanListItem({
                     {formatRelativeTime(item.createdAt)}
                   </span>
                 </div>
+                <div className="font-semibold truncate pb-1">
+                  {item.spotName}
+                </div>
                 <div className="text-sm text-muted-foreground truncate">
                   {item.address.city} - {item.address.site}
                 </div>

--- a/src/types/suggestion.ts
+++ b/src/types/suggestion.ts
@@ -16,6 +16,7 @@ export interface TrashCanSuggestion {
     city: string;
     site: string;
   };
+  spotName: string;
   trashType: TrashType;
   imageUrl: string;
   status: SuggestionStatus;


### PR DESCRIPTION
## 📌 작업 내용 및 특이 사항
- 제보 아이템의 이름을 보여줬으면 좋겠다는 요청에 맞게 업데이트

  - AS-IS
    <img width="697" height="468" alt="스크린샷 2025-10-08 오후 5 26 28" src="https://github.com/user-attachments/assets/f3e0cdfe-cb5f-43d4-b325-ebd443056db4" />

  - TO-BE
    <img width="697" height="468" alt="스크린샷 2025-10-08 오후 5 26 44" src="https://github.com/user-attachments/assets/e03cfe3a-99f0-451a-908b-b110a722eb04" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trash can suggestions now display the spot name in the collapsed item view.
  * The spot name appears as a bold, truncated line between the creation time and the city/site, improving quick scanning and identification of items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->