### PR TITLE
fix: 유저 방문기록의 쓰레기통 업데이트 시간이 잘못 표기되는 현상 수정

### DIFF
--- a/src/components/users/user-detail.tsx
+++ b/src/components/users/user-detail.tsx
@@ -83,7 +83,7 @@ export default function UserDetail({ userId }: UserDetailProps) {
                     )}
                   </div>
                   <div className="text-xs text-gray-500">
-                    {formatRelativeTime(spot.createdAt)}
+                    {formatRelativeTime(spot.updatedAt)}
                   </div>
                 </div>
               </Card>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -31,5 +31,5 @@ export interface VisitedSpot {
   trashType: TrashType;
   imageUrl?: string;
   status: ReportStatus;
-  createdAt: string;
+  updatedAt: string;
 }


### PR DESCRIPTION
## 📌 작업 내용 및 특이 사항

- 유저가 방문한 기록을 볼 때, 쓰레기통이 업데이트된 시간이 NaN으로 잘못 표기되는 현상 수정
  - 응답 받은 타입의 값을 잘못 사용하고 있었음 (createdAt -> updatedAt)
  <img width="697" height="389" alt="스크린샷 2025-10-08 오후 5 35 44" src="https://github.com/user-attachments/assets/bd135bff-3525-47e8-a3f4-b1d62e566928" />

