### PR TITLE
feat: 제보/신고 아이템 반려 사유 작성 가능하도록 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-toggle": "^1.1.10",
+    "@radix-ui/react-toggle-group": "^1.1.11",
     "@tailwindcss/postcss": "^4.1.10",
     "@tanstack/react-query": "^5.81.5",
     "@tanstack/react-query-devtools": "^5.81.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-toggle':
+        specifier: ^1.1.10
+        version: 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle-group':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tailwindcss/postcss':
         specifier: ^4.1.10
         version: 4.1.10
@@ -407,6 +413,9 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
   '@radix-ui/react-accordion@1.2.11':
     resolution: {integrity: sha512-l3W5D54emV2ues7jjeG1xcyN7S3jnK3zE2zHqgn0CmMsy9lNJwmgcrmaxS+7ipw15FAivzKNzH3d5EcGoFKw0A==}
     peerDependencies:
@@ -521,8 +530,56 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2369,6 +2426,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
   '@radix-ui/react-accordion@1.2.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -2467,9 +2526,58 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8

--- a/src/components/reports/report-list.tsx
+++ b/src/components/reports/report-list.tsx
@@ -35,8 +35,17 @@ export default function ReportList() {
     mutateReportStatus({ reportId, spotId, status: COMMON_STATUS.APPROVE });
   };
 
-  const handleReject = (reportId: number, spotId: number) => {
-    mutateReportStatus({ reportId, spotId, status: COMMON_STATUS.REJECT });
+  const handleReject = (
+    reportId: number,
+    spotId: number,
+    rejectReason: string
+  ) => {
+    mutateReportStatus({
+      reportId,
+      spotId,
+      status: COMMON_STATUS.REJECT,
+      rejectReason,
+    });
   };
 
   const handleFilterChange = (type: string) => {

--- a/src/components/suggestions/trash-can-list.tsx
+++ b/src/components/suggestions/trash-can-list.tsx
@@ -35,8 +35,8 @@ export default function TrashCanList() {
     mutateSuggestionStatus({ id, status: COMMON_STATUS.APPROVE });
   };
 
-  const handleReject = (id: number) => {
-    mutateSuggestionStatus({ id, status: COMMON_STATUS.REJECT });
+  const handleReject = (id: number, reason: string) => {
+    mutateSuggestionStatus({ id, status: COMMON_STATUS.REJECT, reason });
   };
 
   const handleFilterChange = (status: string) => {

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import * as React from "react";
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import { type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { toggleVariants } from "@/components/ui/toggle";
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants>
+>({
+  size: "default",
+  variant: "default",
+});
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      className={cn(
+        "group/toggle-group flex w-fit items-center rounded-md data-[variant=outline]:shadow-xs",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        "min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+}
+
+export { ToggleGroup, ToggleGroupItem };

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import * as React from "react";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, toggleVariants };

--- a/src/hooks/useReportAction.ts
+++ b/src/hooks/useReportAction.ts
@@ -15,11 +15,13 @@ export function useReportAction() {
       reportId,
       spotId,
       status,
+      rejectReason,
     }: {
       reportId: number;
       spotId: number;
       status: string;
-    }) => updateReportStatus({ reportId, spotId, status }),
+      rejectReason?: string;
+    }) => updateReportStatus({ reportId, spotId, status, rejectReason }),
     onMutate: async ({ spotId, status }) => {
       const queries = queryClient.getQueriesData<ReportPage>({
         queryKey: ["reports"],

--- a/src/hooks/useSuggestionAction.ts
+++ b/src/hooks/useSuggestionAction.ts
@@ -11,10 +11,12 @@ import { toast } from "@/components/ui/sonner";
  * @typedef {object} UseSuggestionActionParams
  * @property {number} id - 제보 ID
  * @property {SuggestionStatus} status - 변경할 상태
+ * @property {string} [reason] - 반려 사유 (반려 시 필수)
  */
 interface UseSuggestionActionParams {
   id: number;
   status: SuggestionStatus;
+  reason?: string;
 }
 
 /**
@@ -25,8 +27,8 @@ export function useSuggestionAction() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, status }: UseSuggestionActionParams) =>
-      updateSuggestionStatus({ id, status }),
+    mutationFn: ({ id, status, reason }: UseSuggestionActionParams) =>
+      updateSuggestionStatus({ id, status, reason }),
     onMutate: async ({ id, status }) => {
       const queries = queryClient.getQueriesData<SuggestionPage>({
         queryKey: ["suggestions"],

--- a/src/lib/api/reports.ts
+++ b/src/lib/api/reports.ts
@@ -60,15 +60,20 @@ export async function updateReportStatus({
   reportId,
   spotId,
   status,
+  rejectReason,
 }: {
   reportId: number;
   spotId: number;
   status: string;
+  rejectReason?: string;
 }): Promise<void> {
   const url = process.env.NEXT_PUBLIC_API_URL + `/v1/admin/reports/${reportId}`;
+  const body = rejectReason
+    ? { spotId, status, rejectReason }
+    : { spotId, status };
   const res = await apiRequest(url, {
     method: "PUT",
-    body: JSON.stringify({ spotId, status }),
+    body: JSON.stringify(body),
   });
 
   if (!res.ok) {

--- a/src/lib/api/suggestions.ts
+++ b/src/lib/api/suggestions.ts
@@ -62,18 +62,19 @@ export async function fetchSuggestionDetail(
 export async function updateSuggestionStatus({
   id,
   status,
+  reason,
 }: {
   id: number;
   status: SuggestionStatus;
+  reason?: string;
 }): Promise<void> {
-  const url =
-    process.env.NEXT_PUBLIC_API_URL + `/v1/admin/suggestions/${id}`;
+  const url = process.env.NEXT_PUBLIC_API_URL + `/v1/admin/suggestions/${id}`;
   const res = await apiRequest(url, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ status }),
+    body: JSON.stringify({ status, reason }),
   });
 
   if (!res.ok) {

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -52,6 +52,7 @@ export interface TrashCanReport {
   imageUrl: string;
   status: ReportStatus;
   createdAt: string;
+  rejectReason?: string;
 }
 
 export interface ReportResponseData {

--- a/src/types/suggestion.ts
+++ b/src/types/suggestion.ts
@@ -21,6 +21,7 @@ export interface TrashCanSuggestion {
   imageUrl: string;
   status: SuggestionStatus;
   createdAt: string;
+  rejectReason?: string;
 }
 
 export interface TrashCanSuggestionResponseData {


### PR DESCRIPTION
## 📌 작업 내용 및 특이 사항

- 제보/신고 리스트 아이템에서 해당 아이템을 반려할 경우 사유를 작성할 수 있도록 UI 수정

  - 승인/반려 선택 전
    <img width="480" height="640" alt="스크린샷 2025-10-13 오전 1 42 21" src="https://github.com/user-attachments/assets/ecc4dea4-6fa6-4527-bf37-1195246909ad" />

  - 승인
    <img width="480" height="640" alt="스크린샷 2025-10-13 오전 1 42 25" src="https://github.com/user-attachments/assets/705cc4ae-f70b-4bf9-9e0e-bae91bb3204a" />

  - 반려
    <img width="480" height="640" alt="스크린샷 2025-10-13 오전 1 42 52" src="https://github.com/user-attachments/assets/68708355-31b7-48b4-8f19-420e0ad83cea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a guided Approve/Reject flow for reports and suggestions using a toggle with a confirmation step.
  - Rejection now requires a reason; confirmation is disabled until provided.
  - Rejection reasons are displayed in item details when available.

- UI
  - Introduced new toggle and toggle-group controls with size and variant styling for clearer action selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->