### PR TITLE
feat: 제보 아이템 쓰레기통 이름 클릭 시 복사

### DIFF
--- a/src/components/suggestions/trash-can-list-item.tsx
+++ b/src/components/suggestions/trash-can-list-item.tsx
@@ -18,6 +18,8 @@ import {
 } from "@/components/ui/accordion";
 import Image from "next/image";
 import { useState } from "react";
+import { CopyIcon } from "lucide-react";
+import { toast } from "sonner";
 
 interface TrashCanListItemProps {
   item: TrashCanSuggestion;
@@ -37,6 +39,12 @@ export default function TrashCanListItem({
   const [selectedAction, setSelectedAction] = useState<string>("");
   const [rejectReason, setRejectReason] = useState<string>("");
 
+  const handleCopy = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    navigator.clipboard.writeText(item.spotName);
+    toast.success("클립보드에 저장하였습니다.");
+  };
+
   return (
     <Card className="hover:shadow-md transition-shadow py-2">
       <Accordion type="single" collapsible>
@@ -50,9 +58,15 @@ export default function TrashCanListItem({
                     {formatRelativeTime(item.createdAt)}
                   </span>
                 </div>
-                <div className="font-semibold truncate pb-1">
-                  {item.spotName}
-                </div>
+                <button
+                  className="group font-semibold truncate pb-1 flex gap-2 items-center"
+                  onClick={handleCopy}
+                >
+                  <span className="group-hover:underline underline-offset-2">
+                    {item.spotName}
+                  </span>
+                  <CopyIcon className="w-4 h-4" />
+                </button>
                 <div className="text-sm text-muted-foreground truncate">
                   {item.address.city} - {item.address.site}
                 </div>


### PR DESCRIPTION
## 📌 작업 내용 및 특이 사항

- 제보 아이템의 쓰레기통 이름을 클릭할 경우, 클립보드에 복사하는 기능을 추가

<img width="651" height="596" alt="스크린샷 2025-10-21 오후 9 10 52" src="https://github.com/user-attachments/assets/11f00f5b-aced-4c03-8b10-a5d4cf724281" />