### PR TITLE
fix: 장소 이름 대신 주소 복사로 변경

### DIFF
--- a/src/components/suggestions/trash-can-list-item.tsx
+++ b/src/components/suggestions/trash-can-list-item.tsx
@@ -48,7 +48,7 @@ export default function TrashCanListItem({
 
   const handleCopy = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    navigator.clipboard.writeText(item.spotName);
+    navigator.clipboard.writeText(item.address.site);
     toast.success("클립보드에 저장하였습니다.");
   };
 
@@ -65,24 +65,31 @@ export default function TrashCanListItem({
                     {formatRelativeTime(item.createdAt)}
                   </span>
                 </div>
-                <button
-                  className="group font-semibold truncate pb-1 flex gap-2 items-center"
-                  onClick={handleCopy}
-                >
-                  <span className="group-hover:underline underline-offset-2">
+                  <div className="group-hover:underline underline-offset-2">
                     {item.spotName}
-                  </span>
-                  <CopyIcon className="w-4 h-4" />
-                </button>
+                  </div>
 
-                <Link
-                  href={googleMapSearchUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground truncate hover:underline underline-offset-2"
-                >
-                  {item.address.city} - {item.address.site}
-                </Link>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <Link
+                    href={googleMapSearchUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-muted-foreground truncate hover:underline underline-offset-2"
+                  >
+                    {item.address.city} - {item.address.site}
+                  </Link>
+                </div>
+                <div className="mt-1 flex items-center gap-2">
+                  <button
+                    className="group font-semibold truncate flex gap-1 items-center"
+                    onClick={handleCopy}
+                  >
+                    <CopyIcon className="w-4 h-4" />
+                    <span className="group-hover:underline underline-offset-2">
+                      주소 복사
+                    </span>
+                  </button>
+                </div>
               </div>
 
               <div className="flex items-center gap-2 flex-shrink-0">

--- a/src/components/suggestions/trash-can-list-item.tsx
+++ b/src/components/suggestions/trash-can-list-item.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/accordion";
 import Image from "next/image";
 import { useState } from "react";
-import { CopyIcon } from "lucide-react";
+import { CopyIcon, MapPin } from "lucide-react";
 import { toast } from "sonner";
 import Link from "next/link";
 
@@ -68,27 +68,27 @@ export default function TrashCanListItem({
                   <div className="group-hover:underline underline-offset-2">
                     {item.spotName}
                   </div>
-
-                <div className="flex items-center gap-2 flex-shrink-0">
-                  <Link
-                    href={googleMapSearchUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-muted-foreground truncate hover:underline underline-offset-2"
-                  >
-                    {item.address.city} - {item.address.site}
-                  </Link>
-                </div>
-                <div className="mt-1 flex items-center gap-2">
+                <div className="flex items-center gap-2 flex-shrink-0 mt-1">
                   <button
                     className="group font-semibold truncate flex gap-1 items-center"
                     onClick={handleCopy}
                   >
                     <CopyIcon className="w-4 h-4" />
                     <span className="group-hover:underline underline-offset-2">
-                      주소 복사
+                      {item.address.site}
                     </span>
                   </button>
+                </div>
+                <div className="mt-1 flex items-center gap-2">
+                  <Link
+                    href={googleMapSearchUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-sm text-muted-foreground truncate hover:underline underline-offset-2"
+                  >
+                    <MapPin className="w-4 h-4" aria-hidden="true" />
+                    <span>구글맵 바로가기</span>
+                  </Link>
                 </div>
               </div>
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이 사항

- 6347a5838b79d1dc0d34f8b280d7ed5cbbceef7c: 주소 복사로 변경

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added a dedicated "Copy Address" button group that copies the site/address text (spot name is no longer the primary copy target).
  * Introduced a MapPin icon and a distinct Google Maps link block with label for clearer map access.
  * Simplified spot name display and repositioned the copy area for a cleaner, more discoverable layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->